### PR TITLE
Remove alt text of image tag

### DIFF
--- a/common/initdb.d/test_country.tsv
+++ b/common/initdb.d/test_country.tsv
@@ -1,250 +1,250 @@
 国・地域名	ISO 3166-1における英語名	numeric	alpha-3	alpha-2	場所	各行政区分
-アイスランドの旗 アイスランド	Iceland	352	ISL	IS	北ヨーロッパ	ISO 3166-2:IS
-アイルランドの旗 アイルランド	Ireland	372	IRL	IE	西ヨーロッパ	ISO 3166-2:IE
-アゼルバイジャンの旗 アゼルバイジャン	Azerbaijan	031	AZE	AZ	東ヨーロッパ	ISO 3166-2:AZ
-アフガニスタンの旗 アフガニスタン	Afghanistan	004	AFG	AF	中東	ISO 3166-2:AF
-アメリカ合衆国の旗 アメリカ合衆国	United States	840	USA	US	北アメリカ	ISO 3166-2:US
-アメリカ領ヴァージン諸島の旗 アメリカ領ヴァージン諸島	Virgin Islands, U.S.	850	VIR	VI	中央アメリカ	ISO 3166-2:VI
-アメリカ領サモアの旗 アメリカ領サモア	American Samoa	016	ASM	AS	オセアニア	ISO 3166-2:AS
-アラブ首長国連邦の旗 アラブ首長国連邦	United Arab Emirates	784	ARE	AE	中東	ISO 3166-2:AE
-アルジェリアの旗 アルジェリア	Algeria	012	DZA	DZ	北アフリカ	ISO 3166-2:DZ
-アルゼンチンの旗 アルゼンチン	Argentina	032	ARG	AR	南アメリカ	ISO 3166-2:AR
-アルバの旗 アルバ	Aruba	533	ABW	AW	中央アメリカ	ISO 3166-2:AW
-アルバニアの旗 アルバニア	Albania	008	ALB	AL	東ヨーロッパ	ISO 3166-2:AL
-アルメニアの旗 アルメニア	Armenia	051	ARM	AM	東ヨーロッパ	ISO 3166-2:AM
-アンギラの旗 アンギラ	Anguilla	660	AIA	AI	中央アメリカ	ISO 3166-2:AI
-アンゴラの旗 アンゴラ	Angola	024	AGO	AO	南アフリカ	ISO 3166-2:AO
-アンティグア・バーブーダの旗 アンティグア・バーブーダ	Antigua and Barbuda	028	ATG	AG	中央アメリカ	ISO 3166-2:AG
-アンドラの旗 アンドラ	Andorra	020	AND	AD	西ヨーロッパ	ISO 3166-2:AD
-イエメンの旗 イエメン	Yemen	887	YEM	YE	中東	ISO 3166-2:YE
-イギリスの旗 イギリス	United Kingdom	826	GBR	GB	西ヨーロッパ	ISO 3166-2:GB
-イギリス領インド洋地域の旗 イギリス領インド洋地域	British Indian Ocean Territory	086	IOT	IO	インド洋地域	ISO 3166-2:IO
-イギリス領ヴァージン諸島の旗 イギリス領ヴァージン諸島	Virgin Islands, British	092	VGB	VG	中央アメリカ	ISO 3166-2:VG
-イスラエルの旗 イスラエル	Israel	376	ISR	IL	中東	ISO 3166-2:IL
-イタリアの旗 イタリア	Italy	380	ITA	IT	西ヨーロッパ	ISO 3166-2:IT
-イラクの旗 イラク	Iraq	368	IRQ	IQ	中東	ISO 3166-2:IQ
-イランの旗 イラン・イスラム共和国	Iran, Islamic Republic of	364	IRN	IR	中東	ISO 3166-2:IR
-インドの旗 インド	India	356	IND	IN	南アジア	ISO 3166-2:IN
-インドネシアの旗 インドネシア	Indonesia	360	IDN	ID	東南アジア	ISO 3166-2:ID
-ウォリス・フツナの旗 ウォリス・フツナ	Wallis and Futuna	876	WLF	WF	オセアニア	ISO 3166-2:WF
-ウガンダの旗 ウガンダ	Uganda	800	UGA	UG	中央アフリカ	ISO 3166-2:UG
-ウクライナの旗 ウクライナ	Ukraine	804	UKR	UA	東ヨーロッパ	ISO 3166-2:UA
-ウズベキスタンの旗 ウズベキスタン	Uzbekistan	860	UZB	UZ	中央アジア	ISO 3166-2:UZ
-ウルグアイの旗 ウルグアイ	Uruguay	858	URY	UY	南アメリカ	ISO 3166-2:UY
-エクアドルの旗 エクアドル	Ecuador	218	ECU	EC	南アメリカ	ISO 3166-2:EC
-エジプトの旗 エジプト	Egypt	818	EGY	EG	北アフリカ	ISO 3166-2:EG
-エストニアの旗 エストニア	Estonia	233	EST	EE	東ヨーロッパ	ISO 3166-2:EE
-エスワティニの旗 エスワティニ	Eswatini	748	SWZ	SZ	南アフリカ	ISO 3166-2:SZ
-エチオピアの旗 エチオピア	Ethiopia	231	ETH	ET	東アフリカ	ISO 3166-2:ET
-エリトリアの旗 エリトリア	Eritrea	232	ERI	ER	東アフリカ	ISO 3166-2:ER
-エルサルバドルの旗 エルサルバドル	El Salvador	222	SLV	SV	中央アメリカ	ISO 3166-2:SV
-オーストラリアの旗 オーストラリア	Australia	036	AUS	AU	オセアニア	ISO 3166-2:AU
-オーストリアの旗 オーストリア	Austria	040	AUT	AT	東ヨーロッパ	ISO 3166-2:AT
-オーランド諸島の旗 オーランド諸島	Åland Islands	248	ALA	AX	北ヨーロッパ	ISO 3166-2:AX
-オマーンの旗 オマーン	Oman	512	OMN	OM	中東	ISO 3166-2:OM
-オランダの旗 オランダ	Netherlands	528	NLD	NL	西ヨーロッパ	ISO 3166-2:NL
-ガーナの旗 ガーナ	Ghana	288	GHA	GH	西アフリカ	ISO 3166-2:GH
-カーボベルデの旗 カーボベルデ	Cape Verde	132	CPV	CV	西アフリカ	ISO 3166-2:CV
-ガーンジー島の旗 ガーンジー	Guernsey	831	GGY	GG	西ヨーロッパ	ISO 3166-2:GG
-ガイアナの旗 ガイアナ	Guyana	328	GUY	GY	南アメリカ	ISO 3166-2:GY
-カザフスタンの旗 カザフスタン	Kazakhstan	398	KAZ	KZ	中央アジア	ISO 3166-2:KZ
-カタールの旗 カタール	Qatar	634	QAT	QA	中東	ISO 3166-2:QA
-アメリカ合衆国の旗 合衆国領有小離島	United States Minor Outlying Islands	581	UMI	UM	オセアニア	ISO 3166-2:UM
-カナダの旗 カナダ	Canada	124	CAN	CA	北アメリカ	ISO 3166-2:CA
-ガボンの旗 ガボン	Gabon	266	GAB	GA	中央アフリカ	ISO 3166-2:GA
-カメルーンの旗 カメルーン	Cameroon	120	CMR	CM	中央アフリカ	ISO 3166-2:CM
-ガンビアの旗 ガンビア	Gambia	270	GMB	GM	西アフリカ	ISO 3166-2:GM
-カンボジアの旗 カンボジア	Cambodia	116	KHM	KH	東南アジア	ISO 3166-2:KH
-北マリアナ諸島の旗 北マリアナ諸島	Northern Mariana Islands	580	MNP	MP	オセアニア	ISO 3166-2:MP
-ギニアの旗 ギニア	Guinea	324	GIN	GN	西アフリカ	ISO 3166-2:GN
-ギニアビサウの旗 ギニアビサウ	Guinea-Bissau	624	GNB	GW	西アフリカ	ISO 3166-2:GW
-キプロスの旗 キプロス	Cyprus	196	CYP	CY	地中海地域	ISO 3166-2:CY
-キューバの旗 キューバ	Cuba	192	CUB	CU	中央アメリカ	ISO 3166-2:CU
-キュラソー島の旗 キュラソー	Curaçao	531	CUW	CW	中央アメリカ	ISO 3166-2:CW
-ギリシャの旗 ギリシャ	Greece	300	GRC	GR	西ヨーロッパ	ISO 3166-2:GR
-キリバスの旗 キリバス	Kiribati	296	KIR	KI	オセアニア	ISO 3166-2:KI
-キルギスの旗 キルギス	Kyrgyzstan	417	KGZ	KG	中央アジア	ISO 3166-2:KG
-グアテマラの旗 グアテマラ	Guatemala	320	GTM	GT	中央アメリカ	ISO 3166-2:GT
-グアドループの旗 グアドループ	Guadeloupe	312	GLP	GP	中央アメリカ	ISO 3166-2:GP
-グアムの旗 グアム	Guam	316	GUM	GU	オセアニア	ISO 3166-2:GU
-クウェートの旗 クウェート	Kuwait	414	KWT	KW	中東	ISO 3166-2:KW
-クック諸島の旗 クック諸島	Cook Islands	184	COK	CK	オセアニア	ISO 3166-2:CK
-グリーンランドの旗 グリーンランド	Greenland	304	GRL	GL	北ヨーロッパ	ISO 3166-2:GL
-クリスマス島 (オーストラリア)の旗 クリスマス島	Christmas Island	162	CXR	CX	オセアニア	ISO 3166-2:CX
-グレナダの旗 グレナダ	Grenada	308	GRD	GD	中央アメリカ	ISO 3166-2:GD
-クロアチアの旗 クロアチア	Croatia	191	HRV	HR	東ヨーロッパ	ISO 3166-2:HR
-ケイマン諸島の旗 ケイマン諸島	Cayman Islands	136	CYM	KY	中央アメリカ	ISO 3166-2:KY
-ケニアの旗 ケニア	Kenya	404	KEN	KE	東アフリカ	ISO 3166-2:KE
-コートジボワールの旗 コートジボワール	Côte d'Ivoire	384	CIV	CI	西アフリカ	ISO 3166-2:CI
-ココス諸島の旗 ココス（キーリング）諸島	Cocos (Keeling) Islands	166	CCK	CC	インド洋地域	ISO 3166-2:CC
-コスタリカの旗 コスタリカ	Costa Rica	188	CRI	CR	中央アメリカ	ISO 3166-2:CR
-コモロの旗 コモロ	Comoros	174	COM	KM	インド洋地域	ISO 3166-2:KM
-コロンビアの旗 コロンビア	Colombia	170	COL	CO	南アメリカ	ISO 3166-2:CO
-コンゴ共和国の旗 コンゴ共和国	Congo	178	COG	CG	中央アフリカ	ISO 3166-2:CG
-コンゴ民主共和国の旗 コンゴ民主共和国	Congo, the Democratic Republic of the	180	COD	CD	中央アフリカ	ISO 3166-2:CD
-サウジアラビアの旗 サウジアラビア	Saudi Arabia	682	SAU	SA	中東	ISO 3166-2:SA
-サウスジョージア・サウスサンドウィッチ諸島の旗 サウスジョージア・サウスサンドウィッチ諸島	South Georgia and the South Sandwich Islands	239	SGS	GS	南アメリカ	ISO 3166-2:GS
-サモアの旗 サモア	Samoa	882	WSM	WS	オセアニア	ISO 3166-2:WS
-サントメ・プリンシペの旗 サントメ・プリンシペ	Sao Tome and Principe	678	STP	ST	中央アフリカ	ISO 3166-2:ST
-サン・バルテルミー島の旗 サン・バルテルミー	Saint Barthélemy	652	BLM	BL	中央アメリカ	ISO 3166-2:BL
-ザンビアの旗 ザンビア	Zambia	894	ZMB	ZM	南アフリカ	ISO 3166-2:ZM
-サンピエール島・ミクロン島の旗 サンピエール島・ミクロン島	Saint Pierre and Miquelon	666	SPM	PM	北アメリカ	ISO 3166-2:PM
-サンマリノの旗 サンマリノ	San Marino	674	SMR	SM	西ヨーロッパ	ISO 3166-2:SM
-フランスの旗 サン・マルタン（フランス領）	Saint Martin (French part)	663	MAF	MF	中央アメリカ	ISO 3166-2:MF
-シエラレオネの旗 シエラレオネ	Sierra Leone	694	SLE	SL	西アフリカ	ISO 3166-2:SL
-ジブチの旗 ジブチ	Djibouti	262	DJI	DJ	東アフリカ	ISO 3166-2:DJ
-ジブラルタルの旗 ジブラルタル	Gibraltar	292	GIB	GI	西ヨーロッパ	ISO 3166-2:GI
-ジャージー島の旗 ジャージー	Jersey	832	JEY	JE	西ヨーロッパ	ISO 3166-2:JE
-ジャマイカの旗 ジャマイカ	Jamaica	388	JAM	JM	中央アメリカ	ISO 3166-2:JM
-ジョージア (国)の旗 ジョージア	Georgia	268	GEO	GE	東ヨーロッパ	ISO 3166-2:GE
-シリアの旗 シリア・アラブ共和国	Syrian Arab Republic	760	SYR	SY	中東	ISO 3166-2:SY
-シンガポールの旗 シンガポール	Singapore	702	SGP	SG	東南アジア	ISO 3166-2:SG
-シント・マールテンの旗 シント・マールテン（オランダ領）	Sint Maarten (Dutch part)	534	SXM	SX	中央アメリカ	ISO 3166-2:SX
-ジンバブエの旗 ジンバブエ	Zimbabwe	716	ZWE	ZW	南アフリカ	ISO 3166-2:ZW
-スイスの旗 スイス	Switzerland	756	CHE	CH	西ヨーロッパ	ISO 3166-2:CH
-スウェーデンの旗 スウェーデン	Sweden	752	SWE	SE	北ヨーロッパ	ISO 3166-2:SE
-スーダンの旗 スーダン	Sudan	729	SDN	SD	東アフリカ	ISO 3166-2:SD
-ノルウェーの旗 スヴァールバル諸島およびヤンマイエン島	Svalbard and Jan Mayen	744	SJM	SJ	北ヨーロッパ	ISO 3166-2:SJ
-スペインの旗 スペイン	Spain	724	ESP	ES	西ヨーロッパ	ISO 3166-2:ES
-スリナムの旗 スリナム	Suriname	740	SUR	SR	南アメリカ	ISO 3166-2:SR
-スリランカの旗 スリランカ	Sri Lanka	144	LKA	LK	南アジア	ISO 3166-2:LK
-スロバキアの旗 スロバキア	Slovakia	703	SVK	SK	東ヨーロッパ	ISO 3166-2:SK
-スロベニアの旗 スロベニア	Slovenia	705	SVN	SI	東ヨーロッパ	ISO 3166-2:SI
-セーシェルの旗 セーシェル	Seychelles	690	SYC	SC	インド洋地域	ISO 3166-2:SC
-赤道ギニアの旗 赤道ギニア	Equatorial Guinea	226	GNQ	GQ	中央アフリカ	ISO 3166-2:GQ
-セネガルの旗 セネガル	Senegal	686	SEN	SN	西アフリカ	ISO 3166-2:SN
-セルビアの旗 セルビア	Serbia	688	SRB	RS	東ヨーロッパ	ISO 3166-2:RS
-セントクリストファー・ネイビスの旗 セントクリストファー・ネイビス	Saint Kitts and Nevis	659	KNA	KN	中央アメリカ	ISO 3166-2:KN
-セントビンセント・グレナディーンの旗 セントビンセントおよびグレナディーン諸島	Saint Vincent and the Grenadines	670	VCT	VC	中央アメリカ	ISO 3166-2:VC
-セントヘレナの旗 セントヘレナ・アセンションおよびトリスタンダクーニャ	Saint Helena, Ascension and Tristan da Cunha	654	SHN	SH	西アフリカ	ISO 3166-2:SH
-セントルシアの旗 セントルシア	Saint Lucia	662	LCA	LC	中央アメリカ	ISO 3166-2:LC
-ソマリアの旗 ソマリア	Somalia	706	SOM	SO	東アフリカ	ISO 3166-2:SO
-ソロモン諸島の旗 ソロモン諸島	Solomon Islands	090	SLB	SB	オセアニア	ISO 3166-2:SB
-タークス・カイコス諸島の旗 タークス・カイコス諸島	Turks and Caicos Islands	796	TCA	TC	中央アメリカ	ISO 3166-2:TC
-タイ王国の旗 タイ	Thailand	764	THA	TH	東南アジア	ISO 3166-2:TH
-大韓民国の旗 大韓民国	Korea, Republic of	410	KOR	KR	東アジア	ISO 3166-2:KR
-中華民国の旗 中国台湾省（中華民国）	Taiwan, Province of China	158	TWN	TW	東アジア	ISO 3166-2:TW
-タジキスタンの旗 タジキスタン	Tajikistan	762	TJK	TJ	中央アジア	ISO 3166-2:TJ
-タンザニアの旗 タンザニア	Tanzania, United Republic of	834	TZA	TZ	東アフリカ	ISO 3166-2:TZ
-チェコの旗 チェコ	Czechia	203	CZE	CZ	東ヨーロッパ	ISO 3166-2:CZ
-チャドの旗 チャド	Chad	148	TCD	TD	中央アフリカ	ISO 3166-2:TD
-中央アフリカ共和国の旗 中央アフリカ共和国	Central African Republic	140	CAF	CF	中央アフリカ	ISO 3166-2:CF
-中華人民共和国の旗 中華人民共和国	China	156	CHN	CN	東アジア	ISO 3166-2:CN
-チュニジアの旗 チュニジア	Tunisia	788	TUN	TN	北アフリカ	ISO 3166-2:TN
-朝鮮民主主義人民共和国の旗 朝鮮民主主義人民共和国	Korea, Democratic People's Republic of	408	PRK	KP	東アジア	ISO 3166-2:KP
-チリの旗 チリ	Chile	152	CHL	CL	南アメリカ	ISO 3166-2:CL
-ツバルの旗 ツバル	Tuvalu	798	TUV	TV	オセアニア	ISO 3166-2:TV
-デンマークの旗 デンマーク	Denmark	208	DNK	DK	北ヨーロッパ	ISO 3166-2:DK
-ドイツの旗 ドイツ	Germany	276	DEU	DE	西ヨーロッパ	ISO 3166-2:DE
-トーゴの旗 トーゴ	Togo	768	TGO	TG	西アフリカ	ISO 3166-2:TG
-トケラウの旗 トケラウ	Tokelau	772	TKL	TK	オセアニア	ISO 3166-2:TK
-ドミニカ共和国の旗 ドミニカ共和国	Dominican Republic	214	DOM	DO	中央アメリカ	ISO 3166-2:DO
-ドミニカ国の旗 ドミニカ国	Dominica	212	DMA	DM	中央アメリカ	ISO 3166-2:DM
-トリニダード・トバゴの旗 トリニダード・トバゴ	Trinidad and Tobago	780	TTO	TT	中央アメリカ	ISO 3166-2:TT
-トルクメニスタンの旗 トルクメニスタン	Turkmenistan	795	TKM	TM	中央アジア	ISO 3166-2:TM
-トルコの旗 トルコ	Turkey	792	TUR	TR	中東	ISO 3166-2:TR
-トンガの旗 トンガ	Tonga	776	TON	TO	オセアニア	ISO 3166-2:TO
-ナイジェリアの旗 ナイジェリア	Nigeria	566	NGA	NG	中央アフリカ	ISO 3166-2:NG
-ナウルの旗 ナウル	Nauru	520	NRU	NR	オセアニア	ISO 3166-2:NR
-ナミビアの旗 ナミビア	Namibia	516	NAM	NA	南アフリカ	ISO 3166-2:NA
-南極の旗 南極	Antarctica	010	ATA	AQ	南極	ISO 3166-2:AQ
-ニウエの旗 ニウエ	Niue	570	NIU	NU	オセアニア	ISO 3166-2:NU
-ニカラグアの旗 ニカラグア	Nicaragua	558	NIC	NI	中央アメリカ	ISO 3166-2:NI
-ニジェールの旗 ニジェール	Niger	562	NER	NE	中央アフリカ	ISO 3166-2:NE
-日本の旗 日本	Japan	392	JPN	JP	東アジア	ISO 3166-2:JP
-西サハラの旗 西サハラ	Western Sahara	732	ESH	EH	西アフリカ	ISO 3166-2:EH
-ニューカレドニアの旗 ニューカレドニア	New Caledonia	540	NCL	NC	オセアニア	ISO 3166-2:NC
-ニュージーランドの旗 ニュージーランド	New Zealand	554	NZL	NZ	オセアニア	ISO 3166-2:NZ
-ネパールの旗 ネパール	Nepal	524	NPL	NP	南アジア	ISO 3166-2:NP
-ノーフォーク島の旗 ノーフォーク島	Norfolk Island	574	NFK	NF	オセアニア	ISO 3166-2:NF
-ノルウェーの旗 ノルウェー	Norway	578	NOR	NO	北ヨーロッパ	ISO 3166-2:NO
-オーストラリアの旗 ハード島とマクドナルド諸島	Heard Island and McDonald Islands	334	HMD	HM	インド洋地域	ISO 3166-2:HM
-バーレーンの旗 バーレーン	Bahrain	048	BHR	BH	中東	ISO 3166-2:BH
-ハイチの旗 ハイチ	Haiti	332	HTI	HT	中央アメリカ	ISO 3166-2:HT
-パキスタンの旗 パキスタン	Pakistan	586	PAK	PK	南アジア	ISO 3166-2:PK
-バチカンの旗 バチカン市国	Holy See (Vatican City State)	336	VAT	VA	西ヨーロッパ	ISO 3166-2:VA
-パナマの旗 パナマ	Panama	591	PAN	PA	中央アメリカ	ISO 3166-2:PA
-バヌアツの旗 バヌアツ	Vanuatu	548	VUT	VU	オセアニア	ISO 3166-2:VU
-バハマの旗 バハマ	Bahamas	044	BHS	BS	中央アメリカ	ISO 3166-2:BS
-パプアニューギニアの旗 パプアニューギニア	Papua New Guinea	598	PNG	PG	オセアニア	ISO 3166-2:PG
-バミューダ諸島の旗 バミューダ	Bermuda	060	BMU	BM	中央アメリカ	ISO 3166-2:BM
-パラオの旗 パラオ	Palau	585	PLW	PW	オセアニア	ISO 3166-2:PW
-パラグアイの旗 パラグアイ	Paraguay	600	PRY	PY	南アメリカ	ISO 3166-2:PY
-バルバドスの旗 バルバドス	Barbados	052	BRB	BB	中央アメリカ	ISO 3166-2:BB
-パレスチナの旗 パレスチナ	Palestinian Territory, Occupied	275	PSE	PS	中東	ISO 3166-2:PS
-ハンガリーの旗 ハンガリー	Hungary	348	HUN	HU	東ヨーロッパ	ISO 3166-2:HU
-バングラデシュの旗 バングラデシュ	Bangladesh	050	BGD	BD	南アジア	ISO 3166-2:BD
-東ティモールの旗 東ティモール	Timor-Leste	626	TLS	TL	東南アジア	ISO 3166-2:TL
-ピトケアン諸島の旗 ピトケアン	Pitcairn	612	PCN	PN	オセアニア	ISO 3166-2:PN
-フィジーの旗 フィジー	Fiji	242	FJI	FJ	オセアニア	ISO 3166-2:FJ
-フィリピンの旗 フィリピン	Philippines	608	PHL	PH	東南アジア	ISO 3166-2:PH
-フィンランドの旗 フィンランド	Finland	246	FIN	FI	北ヨーロッパ	ISO 3166-2:FI
-ブータンの旗 ブータン	Bhutan	064	BTN	BT	南アジア	ISO 3166-2:BT
-ノルウェーの旗 ブーベ島	Bouvet Island	074	BVT	BV	南極	ISO 3166-2:BV
-プエルトリコの旗 プエルトリコ	Puerto Rico	630	PRI	PR	中央アメリカ	ISO 3166-2:PR
-フェロー諸島の旗 フェロー諸島	Faroe Islands	234	FRO	FO	北ヨーロッパ	ISO 3166-2:FO
-フォークランド諸島の旗 フォークランド（マルビナス）諸島	Falkland Islands (Malvinas)	238	FLK	FK	南アメリカ	ISO 3166-2:FK
-ブラジルの旗 ブラジル	Brazil	076	BRA	BR	南アメリカ	ISO 3166-2:BR
-フランスの旗 フランス	France	250	FRA	FR	西ヨーロッパ	ISO 3166-2:FR
-フランス領ギアナの旗 フランス領ギアナ	French Guiana	254	GUF	GF	南アメリカ	ISO 3166-2:GF
-フランス領ポリネシアの旗 フランス領ポリネシア	French Polynesia	258	PYF	PF	オセアニア	ISO 3166-2:PF
-Flag of the French Southern and Antarctic Lands.svg フランス領南方・南極地域	French Southern Territories	260	ATF	TF	インド洋地域	ISO 3166-2:TF
-ブルガリアの旗 ブルガリア	Bulgaria	100	BGR	BG	東ヨーロッパ	ISO 3166-2:BG
-ブルキナファソの旗 ブルキナファソ	Burkina Faso	854	BFA	BF	西アフリカ	ISO 3166-2:BF
-ブルネイの旗 ブルネイ・ダルサラーム	Brunei Darussalam	096	BRN	BN	東南アジア	ISO 3166-2:BN
-ブルンジの旗 ブルンジ	Burundi	108	BDI	BI	中央アフリカ	ISO 3166-2:BI
-ベトナムの旗 ベトナム	Viet Nam	704	VNM	VN	東南アジア	ISO 3166-2:VN
-ベナンの旗 ベナン	Benin	204	BEN	BJ	西アフリカ	ISO 3166-2:BJ
-ベネズエラの旗 ベネズエラ・ボリバル共和国	Venezuela, Bolivarian Republic of	862	VEN	VE	南アメリカ	ISO 3166-2:VE
-ベラルーシの旗 ベラルーシ	Belarus	112	BLR	BY	東ヨーロッパ	ISO 3166-2:BY
-ベリーズの旗 ベリーズ	Belize	084	BLZ	BZ	中央アメリカ	ISO 3166-2:BZ
-ペルーの旗 ペルー	Peru	604	PER	PE	南アメリカ	ISO 3166-2:PE
-ベルギーの旗 ベルギー	Belgium	056	BEL	BE	西ヨーロッパ	ISO 3166-2:BE
-ポーランドの旗 ポーランド	Poland	616	POL	PL	東ヨーロッパ	ISO 3166-2:PL
-ボスニア・ヘルツェゴビナの旗 ボスニア・ヘルツェゴビナ	Bosnia and Herzegovina	070	BIH	BA	東ヨーロッパ	ISO 3166-2:BA
-ボツワナの旗 ボツワナ	Botswana	072	BWA	BW	南アフリカ	ISO 3166-2:BW
-オランダの旗 ボネール、シント・ユースタティウスおよびサバ	Bonaire, Saint Eustatius and Saba	535	BES	BQ	中央アメリカ	ISO 3166-2:BQ
-ボリビアの旗 ボリビア多民族国	Bolivia, Plurinational State of	068	BOL	BO	南アメリカ	ISO 3166-2:BO
-ポルトガルの旗 ポルトガル	Portugal	620	PRT	PT	西ヨーロッパ	ISO 3166-2:PT
-香港の旗 香港	Hong Kong	344	HKG	HK	東アジア	ISO 3166-2:HK
-ホンジュラスの旗 ホンジュラス	Honduras	340	HND	HN	中央アメリカ	ISO 3166-2:HN
-マーシャル諸島の旗 マーシャル諸島	Marshall Islands	584	MHL	MH	オセアニア	ISO 3166-2:MH
-マカオの旗 マカオ	Macau	446	MAC	MO	東アジア	ISO 3166-2:MO
-マケドニア共和国の旗 マケドニア旧ユーゴスラビア共和国	Macedonia, the former Yugoslav Republic of	807	MKD	MK	東ヨーロッパ	ISO 3166-2:MK
-マダガスカルの旗 マダガスカル	Madagascar	450	MDG	MG	インド洋地域	ISO 3166-2:MG
-フランスの旗 マヨット	Mayotte	175	MYT	YT	インド洋地域	ISO 3166-2:YT
-マラウイの旗 マラウイ	Malawi	454	MWI	MW	南アフリカ	ISO 3166-2:MW
-マリ共和国の旗 マリ	Mali	466	MLI	ML	西アフリカ	ISO 3166-2:ML
-マルタの旗 マルタ	Malta	470	MLT	MT	地中海地域	ISO 3166-2:MT
-マルティニークの旗 マルティニーク	Martinique	474	MTQ	MQ	中央アメリカ	ISO 3166-2:MQ
-マレーシアの旗 マレーシア	Malaysia	458	MYS	MY	東南アジア	ISO 3166-2:MY
-マン島の旗 マン島	Isle of Man	833	IMN	IM	西ヨーロッパ	ISO 3166-2:IM
-ミクロネシア連邦の旗 ミクロネシア連邦	Micronesia, Federated States of	583	FSM	FM	オセアニア	ISO 3166-2:FM
-南アフリカ共和国の旗 南アフリカ	South Africa	710	ZAF	ZA	南アフリカ	ISO 3166-2:ZA
-南スーダンの旗 南スーダン	South Sudan	728	SSD	SS	東アフリカ	ISO 3166-2:SS
-ミャンマーの旗 ミャンマー	Myanmar	104	MMR	MM	東南アジア	ISO 3166-2:MM
-メキシコの旗 メキシコ	Mexico	484	MEX	MX	中央アメリカ	ISO 3166-2:MX
-モーリシャスの旗 モーリシャス	Mauritius	480	MUS	MU	南アフリカ	ISO 3166-2:MU
-モーリタニアの旗 モーリタニア	Mauritania	478	MRT	MR	西アフリカ	ISO 3166-2:MR
-モザンビークの旗 モザンビーク	Mozambique	508	MOZ	MZ	南アフリカ	ISO 3166-2:MZ
-モナコの旗 モナコ	Monaco	492	MCO	MC	西ヨーロッパ	ISO 3166-2:MC
-モルディブの旗 モルディブ	Maldives	462	MDV	MV	インド洋地域	ISO 3166-2:MV
-モルドバの旗 モルドバ共和国	Moldova, Republic of	498	MDA	MD	東ヨーロッパ	ISO 3166-2:MD
-モロッコの旗 モロッコ	Morocco	504	MAR	MA	北アフリカ	ISO 3166-2:MA
-モンゴル国の旗 モンゴル	Mongolia	496	MNG	MN	東アジア	ISO 3166-2:MN
-モンテネグロの旗 モンテネグロ	Montenegro	499	MNE	ME	東ヨーロッパ	ISO 3166-2:ME
-モントセラトの旗 モントセラト	Montserrat	500	MSR	MS	中央アメリカ	ISO 3166-2:MS
-ヨルダンの旗 ヨルダン	Jordan	400	JOR	JO	中東	ISO 3166-2:JO
-ラオスの旗 ラオス人民民主共和国	Lao People's Democratic Republic	418	LAO	LA	東南アジア	ISO 3166-2:LA
-ラトビアの旗 ラトビア	Latvia	428	LVA	LV	東ヨーロッパ	ISO 3166-2:LV
-リトアニアの旗 リトアニア	Lithuania	440	LTU	LT	東ヨーロッパ	ISO 3166-2:LT
-リビアの旗 リビア	Libya	434	LBY	LY	北アフリカ	ISO 3166-2:LY
-リヒテンシュタインの旗 リヒテンシュタイン	Liechtenstein	438	LIE	LI	西ヨーロッパ	ISO 3166-2:LI
-リベリアの旗 リベリア	Liberia	430	LBR	LR	西アフリカ	ISO 3166-2:LR
-ルーマニアの旗 ルーマニア	Romania	642	ROU	RO	東ヨーロッパ	ISO 3166-2:RO
-ルクセンブルクの旗 ルクセンブルク	Luxembourg	442	LUX	LU	西ヨーロッパ	ISO 3166-2:LU
-ルワンダの旗 ルワンダ	Rwanda	646	RWA	RW	中央アフリカ	ISO 3166-2:RW
-レソトの旗 レソト	Lesotho	426	LSO	LS	南アフリカ	ISO 3166-2:LS
-レバノンの旗 レバノン	Lebanon	422	LBN	LB	中東	ISO 3166-2:LB
-レユニオンの旗 レユニオン	Réunion	638	REU	RE	インド洋地域	ISO 3166-2:RE
-ロシアの旗 ロシア連邦	Russian Federation	643	RUS	RU	ロシア	ISO 3166-2:RU
+アイスランド	Iceland	352	ISL	IS	北ヨーロッパ	ISO 3166-2:IS
+アイルランド	Ireland	372	IRL	IE	西ヨーロッパ	ISO 3166-2:IE
+アゼルバイジャン	Azerbaijan	031	AZE	AZ	東ヨーロッパ	ISO 3166-2:AZ
+アフガニスタン	Afghanistan	004	AFG	AF	中東	ISO 3166-2:AF
+アメリカ合衆国	United States	840	USA	US	北アメリカ	ISO 3166-2:US
+アメリカ領ヴァージン諸島	Virgin Islands, U.S.	850	VIR	VI	中央アメリカ	ISO 3166-2:VI
+アメリカ領サモア	American Samoa	016	ASM	AS	オセアニア	ISO 3166-2:AS
+アラブ首長国連邦	United Arab Emirates	784	ARE	AE	中東	ISO 3166-2:AE
+アルジェリア	Algeria	012	DZA	DZ	北アフリカ	ISO 3166-2:DZ
+アルゼンチン	Argentina	032	ARG	AR	南アメリカ	ISO 3166-2:AR
+アルバ	Aruba	533	ABW	AW	中央アメリカ	ISO 3166-2:AW
+アルバニア	Albania	008	ALB	AL	東ヨーロッパ	ISO 3166-2:AL
+アルメニア	Armenia	051	ARM	AM	東ヨーロッパ	ISO 3166-2:AM
+アンギラ	Anguilla	660	AIA	AI	中央アメリカ	ISO 3166-2:AI
+アンゴラ	Angola	024	AGO	AO	南アフリカ	ISO 3166-2:AO
+アンティグア・バーブーダ	Antigua and Barbuda	028	ATG	AG	中央アメリカ	ISO 3166-2:AG
+アンドラ	Andorra	020	AND	AD	西ヨーロッパ	ISO 3166-2:AD
+イエメン	Yemen	887	YEM	YE	中東	ISO 3166-2:YE
+イギリス	United Kingdom	826	GBR	GB	西ヨーロッパ	ISO 3166-2:GB
+イギリス領インド洋地域	British Indian Ocean Territory	086	IOT	IO	インド洋地域	ISO 3166-2:IO
+イギリス領ヴァージン諸島	Virgin Islands, British	092	VGB	VG	中央アメリカ	ISO 3166-2:VG
+イスラエル	Israel	376	ISR	IL	中東	ISO 3166-2:IL
+イタリア	Italy	380	ITA	IT	西ヨーロッパ	ISO 3166-2:IT
+イラク	Iraq	368	IRQ	IQ	中東	ISO 3166-2:IQ
+イラン・イスラム共和国	Iran, Islamic Republic of	364	IRN	IR	中東	ISO 3166-2:IR
+インド	India	356	IND	IN	南アジア	ISO 3166-2:IN
+インドネシア	Indonesia	360	IDN	ID	東南アジア	ISO 3166-2:ID
+ウォリス・フツナ	Wallis and Futuna	876	WLF	WF	オセアニア	ISO 3166-2:WF
+ウガンダ	Uganda	800	UGA	UG	中央アフリカ	ISO 3166-2:UG
+ウクライナ	Ukraine	804	UKR	UA	東ヨーロッパ	ISO 3166-2:UA
+ウズベキスタン	Uzbekistan	860	UZB	UZ	中央アジア	ISO 3166-2:UZ
+ウルグアイ	Uruguay	858	URY	UY	南アメリカ	ISO 3166-2:UY
+エクアドル	Ecuador	218	ECU	EC	南アメリカ	ISO 3166-2:EC
+エジプト	Egypt	818	EGY	EG	北アフリカ	ISO 3166-2:EG
+エストニア	Estonia	233	EST	EE	東ヨーロッパ	ISO 3166-2:EE
+エスワティニ	Eswatini	748	SWZ	SZ	南アフリカ	ISO 3166-2:SZ
+エチオピア	Ethiopia	231	ETH	ET	東アフリカ	ISO 3166-2:ET
+エリトリア	Eritrea	232	ERI	ER	東アフリカ	ISO 3166-2:ER
+エルサルバドル	El Salvador	222	SLV	SV	中央アメリカ	ISO 3166-2:SV
+オーストラリア	Australia	036	AUS	AU	オセアニア	ISO 3166-2:AU
+オーストリア	Austria	040	AUT	AT	東ヨーロッパ	ISO 3166-2:AT
+オーランド諸島	Åland Islands	248	ALA	AX	北ヨーロッパ	ISO 3166-2:AX
+オマーン	Oman	512	OMN	OM	中東	ISO 3166-2:OM
+オランダ	Netherlands	528	NLD	NL	西ヨーロッパ	ISO 3166-2:NL
+ガーナ	Ghana	288	GHA	GH	西アフリカ	ISO 3166-2:GH
+カーボベルデ	Cape Verde	132	CPV	CV	西アフリカ	ISO 3166-2:CV
+ガーンジー	Guernsey	831	GGY	GG	西ヨーロッパ	ISO 3166-2:GG
+ガイアナ	Guyana	328	GUY	GY	南アメリカ	ISO 3166-2:GY
+カザフスタン	Kazakhstan	398	KAZ	KZ	中央アジア	ISO 3166-2:KZ
+カタール	Qatar	634	QAT	QA	中東	ISO 3166-2:QA
+合衆国領有小離島	United States Minor Outlying Islands	581	UMI	UM	オセアニア	ISO 3166-2:UM
+カナダ	Canada	124	CAN	CA	北アメリカ	ISO 3166-2:CA
+ガボン	Gabon	266	GAB	GA	中央アフリカ	ISO 3166-2:GA
+カメルーン	Cameroon	120	CMR	CM	中央アフリカ	ISO 3166-2:CM
+ガンビア	Gambia	270	GMB	GM	西アフリカ	ISO 3166-2:GM
+カンボジア	Cambodia	116	KHM	KH	東南アジア	ISO 3166-2:KH
+北マリアナ諸島	Northern Mariana Islands	580	MNP	MP	オセアニア	ISO 3166-2:MP
+ギニア	Guinea	324	GIN	GN	西アフリカ	ISO 3166-2:GN
+ギニアビサウ	Guinea-Bissau	624	GNB	GW	西アフリカ	ISO 3166-2:GW
+キプロス	Cyprus	196	CYP	CY	地中海地域	ISO 3166-2:CY
+キューバ	Cuba	192	CUB	CU	中央アメリカ	ISO 3166-2:CU
+キュラソー	Curaçao	531	CUW	CW	中央アメリカ	ISO 3166-2:CW
+ギリシャ	Greece	300	GRC	GR	西ヨーロッパ	ISO 3166-2:GR
+キリバス	Kiribati	296	KIR	KI	オセアニア	ISO 3166-2:KI
+キルギス	Kyrgyzstan	417	KGZ	KG	中央アジア	ISO 3166-2:KG
+グアテマラ	Guatemala	320	GTM	GT	中央アメリカ	ISO 3166-2:GT
+グアドループ	Guadeloupe	312	GLP	GP	中央アメリカ	ISO 3166-2:GP
+グアム	Guam	316	GUM	GU	オセアニア	ISO 3166-2:GU
+クウェート	Kuwait	414	KWT	KW	中東	ISO 3166-2:KW
+クック諸島	Cook Islands	184	COK	CK	オセアニア	ISO 3166-2:CK
+グリーンランド	Greenland	304	GRL	GL	北ヨーロッパ	ISO 3166-2:GL
+クリスマス島	Christmas Island	162	CXR	CX	オセアニア	ISO 3166-2:CX
+グレナダ	Grenada	308	GRD	GD	中央アメリカ	ISO 3166-2:GD
+クロアチア	Croatia	191	HRV	HR	東ヨーロッパ	ISO 3166-2:HR
+ケイマン諸島	Cayman Islands	136	CYM	KY	中央アメリカ	ISO 3166-2:KY
+ケニア	Kenya	404	KEN	KE	東アフリカ	ISO 3166-2:KE
+コートジボワール	Côte d'Ivoire	384	CIV	CI	西アフリカ	ISO 3166-2:CI
+ココス（キーリング）諸島	Cocos (Keeling) Islands	166	CCK	CC	インド洋地域	ISO 3166-2:CC
+コスタリカ	Costa Rica	188	CRI	CR	中央アメリカ	ISO 3166-2:CR
+コモロ	Comoros	174	COM	KM	インド洋地域	ISO 3166-2:KM
+コロンビア	Colombia	170	COL	CO	南アメリカ	ISO 3166-2:CO
+コンゴ共和国	Congo	178	COG	CG	中央アフリカ	ISO 3166-2:CG
+コンゴ民主共和国	Congo, the Democratic Republic of the	180	COD	CD	中央アフリカ	ISO 3166-2:CD
+サウジアラビア	Saudi Arabia	682	SAU	SA	中東	ISO 3166-2:SA
+サウスジョージア・サウスサンドウィッチ諸島	South Georgia and the South Sandwich Islands	239	SGS	GS	南アメリカ	ISO 3166-2:GS
+サモア	Samoa	882	WSM	WS	オセアニア	ISO 3166-2:WS
+サントメ・プリンシペ	Sao Tome and Principe	678	STP	ST	中央アフリカ	ISO 3166-2:ST
+サン・バルテルミー	Saint Barthélemy	652	BLM	BL	中央アメリカ	ISO 3166-2:BL
+ザンビア	Zambia	894	ZMB	ZM	南アフリカ	ISO 3166-2:ZM
+サンピエール島・ミクロン島	Saint Pierre and Miquelon	666	SPM	PM	北アメリカ	ISO 3166-2:PM
+サンマリノ	San Marino	674	SMR	SM	西ヨーロッパ	ISO 3166-2:SM
+サン・マルタン（フランス領）	Saint Martin (French part)	663	MAF	MF	中央アメリカ	ISO 3166-2:MF
+シエラレオネ	Sierra Leone	694	SLE	SL	西アフリカ	ISO 3166-2:SL
+ジブチ	Djibouti	262	DJI	DJ	東アフリカ	ISO 3166-2:DJ
+ジブラルタル	Gibraltar	292	GIB	GI	西ヨーロッパ	ISO 3166-2:GI
+ジャージー	Jersey	832	JEY	JE	西ヨーロッパ	ISO 3166-2:JE
+ジャマイカ	Jamaica	388	JAM	JM	中央アメリカ	ISO 3166-2:JM
+ジョージア	Georgia	268	GEO	GE	東ヨーロッパ	ISO 3166-2:GE
+シリア・アラブ共和国	Syrian Arab Republic	760	SYR	SY	中東	ISO 3166-2:SY
+シンガポール	Singapore	702	SGP	SG	東南アジア	ISO 3166-2:SG
+シント・マールテン（オランダ領）	Sint Maarten (Dutch part)	534	SXM	SX	中央アメリカ	ISO 3166-2:SX
+ジンバブエ	Zimbabwe	716	ZWE	ZW	南アフリカ	ISO 3166-2:ZW
+スイス	Switzerland	756	CHE	CH	西ヨーロッパ	ISO 3166-2:CH
+スウェーデン	Sweden	752	SWE	SE	北ヨーロッパ	ISO 3166-2:SE
+スーダン	Sudan	729	SDN	SD	東アフリカ	ISO 3166-2:SD
+スヴァールバル諸島およびヤンマイエン島	Svalbard and Jan Mayen	744	SJM	SJ	北ヨーロッパ	ISO 3166-2:SJ
+スペイン	Spain	724	ESP	ES	西ヨーロッパ	ISO 3166-2:ES
+スリナム	Suriname	740	SUR	SR	南アメリカ	ISO 3166-2:SR
+スリランカ	Sri Lanka	144	LKA	LK	南アジア	ISO 3166-2:LK
+スロバキア	Slovakia	703	SVK	SK	東ヨーロッパ	ISO 3166-2:SK
+スロベニア	Slovenia	705	SVN	SI	東ヨーロッパ	ISO 3166-2:SI
+セーシェル	Seychelles	690	SYC	SC	インド洋地域	ISO 3166-2:SC
+赤道ギニア	Equatorial Guinea	226	GNQ	GQ	中央アフリカ	ISO 3166-2:GQ
+セネガル	Senegal	686	SEN	SN	西アフリカ	ISO 3166-2:SN
+セルビア	Serbia	688	SRB	RS	東ヨーロッパ	ISO 3166-2:RS
+セントクリストファー・ネイビス	Saint Kitts and Nevis	659	KNA	KN	中央アメリカ	ISO 3166-2:KN
+セントビンセントおよびグレナディーン諸島	Saint Vincent and the Grenadines	670	VCT	VC	中央アメリカ	ISO 3166-2:VC
+セントヘレナ・アセンションおよびトリスタンダクーニャ	Saint Helena, Ascension and Tristan da Cunha	654	SHN	SH	西アフリカ	ISO 3166-2:SH
+セントルシア	Saint Lucia	662	LCA	LC	中央アメリカ	ISO 3166-2:LC
+ソマリア	Somalia	706	SOM	SO	東アフリカ	ISO 3166-2:SO
+ソロモン諸島	Solomon Islands	090	SLB	SB	オセアニア	ISO 3166-2:SB
+タークス・カイコス諸島	Turks and Caicos Islands	796	TCA	TC	中央アメリカ	ISO 3166-2:TC
+タイ	Thailand	764	THA	TH	東南アジア	ISO 3166-2:TH
+大韓民国	Korea, Republic of	410	KOR	KR	東アジア	ISO 3166-2:KR
+中国台湾省（中華民国）	Taiwan, Province of China	158	TWN	TW	東アジア	ISO 3166-2:TW
+タジキスタン	Tajikistan	762	TJK	TJ	中央アジア	ISO 3166-2:TJ
+タンザニア	Tanzania, United Republic of	834	TZA	TZ	東アフリカ	ISO 3166-2:TZ
+チェコ	Czechia	203	CZE	CZ	東ヨーロッパ	ISO 3166-2:CZ
+チャド	Chad	148	TCD	TD	中央アフリカ	ISO 3166-2:TD
+中央アフリカ共和国	Central African Republic	140	CAF	CF	中央アフリカ	ISO 3166-2:CF
+中華人民共和国	China	156	CHN	CN	東アジア	ISO 3166-2:CN
+チュニジア	Tunisia	788	TUN	TN	北アフリカ	ISO 3166-2:TN
+朝鮮民主主義人民共和国	Korea, Democratic People's Republic of	408	PRK	KP	東アジア	ISO 3166-2:KP
+チリ	Chile	152	CHL	CL	南アメリカ	ISO 3166-2:CL
+ツバル	Tuvalu	798	TUV	TV	オセアニア	ISO 3166-2:TV
+デンマーク	Denmark	208	DNK	DK	北ヨーロッパ	ISO 3166-2:DK
+ドイツ	Germany	276	DEU	DE	西ヨーロッパ	ISO 3166-2:DE
+トーゴ	Togo	768	TGO	TG	西アフリカ	ISO 3166-2:TG
+トケラウ	Tokelau	772	TKL	TK	オセアニア	ISO 3166-2:TK
+ドミニカ共和国	Dominican Republic	214	DOM	DO	中央アメリカ	ISO 3166-2:DO
+ドミニカ国	Dominica	212	DMA	DM	中央アメリカ	ISO 3166-2:DM
+トリニダード・トバゴ	Trinidad and Tobago	780	TTO	TT	中央アメリカ	ISO 3166-2:TT
+トルクメニスタン	Turkmenistan	795	TKM	TM	中央アジア	ISO 3166-2:TM
+トルコ	Turkey	792	TUR	TR	中東	ISO 3166-2:TR
+トンガ	Tonga	776	TON	TO	オセアニア	ISO 3166-2:TO
+ナイジェリア	Nigeria	566	NGA	NG	中央アフリカ	ISO 3166-2:NG
+ナウル	Nauru	520	NRU	NR	オセアニア	ISO 3166-2:NR
+ナミビア	Namibia	516	NAM	NA	南アフリカ	ISO 3166-2:NA
+南極	Antarctica	010	ATA	AQ	南極	ISO 3166-2:AQ
+ニウエ	Niue	570	NIU	NU	オセアニア	ISO 3166-2:NU
+ニカラグア	Nicaragua	558	NIC	NI	中央アメリカ	ISO 3166-2:NI
+ニジェール	Niger	562	NER	NE	中央アフリカ	ISO 3166-2:NE
+日本	Japan	392	JPN	JP	東アジア	ISO 3166-2:JP
+西サハラ	Western Sahara	732	ESH	EH	西アフリカ	ISO 3166-2:EH
+ニューカレドニア	New Caledonia	540	NCL	NC	オセアニア	ISO 3166-2:NC
+ニュージーランド	New Zealand	554	NZL	NZ	オセアニア	ISO 3166-2:NZ
+ネパール	Nepal	524	NPL	NP	南アジア	ISO 3166-2:NP
+ノーフォーク島	Norfolk Island	574	NFK	NF	オセアニア	ISO 3166-2:NF
+ノルウェー	Norway	578	NOR	NO	北ヨーロッパ	ISO 3166-2:NO
+ハード島とマクドナルド諸島	Heard Island and McDonald Islands	334	HMD	HM	インド洋地域	ISO 3166-2:HM
+バーレーン	Bahrain	048	BHR	BH	中東	ISO 3166-2:BH
+ハイチ	Haiti	332	HTI	HT	中央アメリカ	ISO 3166-2:HT
+パキスタン	Pakistan	586	PAK	PK	南アジア	ISO 3166-2:PK
+バチカン市国	Holy See (Vatican City State)	336	VAT	VA	西ヨーロッパ	ISO 3166-2:VA
+パナマ	Panama	591	PAN	PA	中央アメリカ	ISO 3166-2:PA
+バヌアツ	Vanuatu	548	VUT	VU	オセアニア	ISO 3166-2:VU
+バハマ	Bahamas	044	BHS	BS	中央アメリカ	ISO 3166-2:BS
+パプアニューギニア	Papua New Guinea	598	PNG	PG	オセアニア	ISO 3166-2:PG
+バミューダ	Bermuda	060	BMU	BM	中央アメリカ	ISO 3166-2:BM
+パラオ	Palau	585	PLW	PW	オセアニア	ISO 3166-2:PW
+パラグアイ	Paraguay	600	PRY	PY	南アメリカ	ISO 3166-2:PY
+バルバドス	Barbados	052	BRB	BB	中央アメリカ	ISO 3166-2:BB
+パレスチナ	Palestinian Territory, Occupied	275	PSE	PS	中東	ISO 3166-2:PS
+ハンガリー	Hungary	348	HUN	HU	東ヨーロッパ	ISO 3166-2:HU
+バングラデシュ	Bangladesh	050	BGD	BD	南アジア	ISO 3166-2:BD
+東ティモール	Timor-Leste	626	TLS	TL	東南アジア	ISO 3166-2:TL
+ピトケアン	Pitcairn	612	PCN	PN	オセアニア	ISO 3166-2:PN
+フィジー	Fiji	242	FJI	FJ	オセアニア	ISO 3166-2:FJ
+フィリピン	Philippines	608	PHL	PH	東南アジア	ISO 3166-2:PH
+フィンランド	Finland	246	FIN	FI	北ヨーロッパ	ISO 3166-2:FI
+ブータン	Bhutan	064	BTN	BT	南アジア	ISO 3166-2:BT
+ブーベ島	Bouvet Island	074	BVT	BV	南極	ISO 3166-2:BV
+プエルトリコ	Puerto Rico	630	PRI	PR	中央アメリカ	ISO 3166-2:PR
+フェロー諸島	Faroe Islands	234	FRO	FO	北ヨーロッパ	ISO 3166-2:FO
+フォークランド（マルビナス）諸島	Falkland Islands (Malvinas)	238	FLK	FK	南アメリカ	ISO 3166-2:FK
+ブラジル	Brazil	076	BRA	BR	南アメリカ	ISO 3166-2:BR
+フランス	France	250	FRA	FR	西ヨーロッパ	ISO 3166-2:FR
+フランス領ギアナ	French Guiana	254	GUF	GF	南アメリカ	ISO 3166-2:GF
+フランス領ポリネシア	French Polynesia	258	PYF	PF	オセアニア	ISO 3166-2:PF
+フランス領南方・南極地域	French Southern Territories	260	ATF	TF	インド洋地域	ISO 3166-2:TF
+ブルガリア	Bulgaria	100	BGR	BG	東ヨーロッパ	ISO 3166-2:BG
+ブルキナファソ	Burkina Faso	854	BFA	BF	西アフリカ	ISO 3166-2:BF
+ブルネイ・ダルサラーム	Brunei Darussalam	096	BRN	BN	東南アジア	ISO 3166-2:BN
+ブルンジ	Burundi	108	BDI	BI	中央アフリカ	ISO 3166-2:BI
+ベトナム	Viet Nam	704	VNM	VN	東南アジア	ISO 3166-2:VN
+ベナン	Benin	204	BEN	BJ	西アフリカ	ISO 3166-2:BJ
+ベネズエラ・ボリバル共和国	Venezuela, Bolivarian Republic of	862	VEN	VE	南アメリカ	ISO 3166-2:VE
+ベラルーシ	Belarus	112	BLR	BY	東ヨーロッパ	ISO 3166-2:BY
+ベリーズ	Belize	084	BLZ	BZ	中央アメリカ	ISO 3166-2:BZ
+ペルー	Peru	604	PER	PE	南アメリカ	ISO 3166-2:PE
+ベルギー	Belgium	056	BEL	BE	西ヨーロッパ	ISO 3166-2:BE
+ポーランド	Poland	616	POL	PL	東ヨーロッパ	ISO 3166-2:PL
+ボスニア・ヘルツェゴビナ	Bosnia and Herzegovina	070	BIH	BA	東ヨーロッパ	ISO 3166-2:BA
+ボツワナ	Botswana	072	BWA	BW	南アフリカ	ISO 3166-2:BW
+ボネール、シント・ユースタティウスおよびサバ	Bonaire, Saint Eustatius and Saba	535	BES	BQ	中央アメリカ	ISO 3166-2:BQ
+ボリビア多民族国	Bolivia, Plurinational State of	068	BOL	BO	南アメリカ	ISO 3166-2:BO
+ポルトガル	Portugal	620	PRT	PT	西ヨーロッパ	ISO 3166-2:PT
+香港	Hong Kong	344	HKG	HK	東アジア	ISO 3166-2:HK
+ホンジュラス	Honduras	340	HND	HN	中央アメリカ	ISO 3166-2:HN
+マーシャル諸島	Marshall Islands	584	MHL	MH	オセアニア	ISO 3166-2:MH
+マカオ	Macau	446	MAC	MO	東アジア	ISO 3166-2:MO
+マケドニア旧ユーゴスラビア共和国	Macedonia, the former Yugoslav Republic of	807	MKD	MK	東ヨーロッパ	ISO 3166-2:MK
+マダガスカル	Madagascar	450	MDG	MG	インド洋地域	ISO 3166-2:MG
+マヨット	Mayotte	175	MYT	YT	インド洋地域	ISO 3166-2:YT
+マラウイ	Malawi	454	MWI	MW	南アフリカ	ISO 3166-2:MW
+マリ	Mali	466	MLI	ML	西アフリカ	ISO 3166-2:ML
+マルタ	Malta	470	MLT	MT	地中海地域	ISO 3166-2:MT
+マルティニーク	Martinique	474	MTQ	MQ	中央アメリカ	ISO 3166-2:MQ
+マレーシア	Malaysia	458	MYS	MY	東南アジア	ISO 3166-2:MY
+マン島	Isle of Man	833	IMN	IM	西ヨーロッパ	ISO 3166-2:IM
+ミクロネシア連邦	Micronesia, Federated States of	583	FSM	FM	オセアニア	ISO 3166-2:FM
+南アフリカ	South Africa	710	ZAF	ZA	南アフリカ	ISO 3166-2:ZA
+南スーダン	South Sudan	728	SSD	SS	東アフリカ	ISO 3166-2:SS
+ミャンマー	Myanmar	104	MMR	MM	東南アジア	ISO 3166-2:MM
+メキシコ	Mexico	484	MEX	MX	中央アメリカ	ISO 3166-2:MX
+モーリシャス	Mauritius	480	MUS	MU	南アフリカ	ISO 3166-2:MU
+モーリタニア	Mauritania	478	MRT	MR	西アフリカ	ISO 3166-2:MR
+モザンビーク	Mozambique	508	MOZ	MZ	南アフリカ	ISO 3166-2:MZ
+モナコ	Monaco	492	MCO	MC	西ヨーロッパ	ISO 3166-2:MC
+モルディブ	Maldives	462	MDV	MV	インド洋地域	ISO 3166-2:MV
+モルドバ共和国	Moldova, Republic of	498	MDA	MD	東ヨーロッパ	ISO 3166-2:MD
+モロッコ	Morocco	504	MAR	MA	北アフリカ	ISO 3166-2:MA
+モンゴル	Mongolia	496	MNG	MN	東アジア	ISO 3166-2:MN
+モンテネグロ	Montenegro	499	MNE	ME	東ヨーロッパ	ISO 3166-2:ME
+モントセラト	Montserrat	500	MSR	MS	中央アメリカ	ISO 3166-2:MS
+ヨルダン	Jordan	400	JOR	JO	中東	ISO 3166-2:JO
+ラオス人民民主共和国	Lao People's Democratic Republic	418	LAO	LA	東南アジア	ISO 3166-2:LA
+ラトビア	Latvia	428	LVA	LV	東ヨーロッパ	ISO 3166-2:LV
+リトアニア	Lithuania	440	LTU	LT	東ヨーロッパ	ISO 3166-2:LT
+リビア	Libya	434	LBY	LY	北アフリカ	ISO 3166-2:LY
+リヒテンシュタイン	Liechtenstein	438	LIE	LI	西ヨーロッパ	ISO 3166-2:LI
+リベリア	Liberia	430	LBR	LR	西アフリカ	ISO 3166-2:LR
+ルーマニア	Romania	642	ROU	RO	東ヨーロッパ	ISO 3166-2:RO
+ルクセンブルク	Luxembourg	442	LUX	LU	西ヨーロッパ	ISO 3166-2:LU
+ルワンダ	Rwanda	646	RWA	RW	中央アフリカ	ISO 3166-2:RW
+レソト	Lesotho	426	LSO	LS	南アフリカ	ISO 3166-2:LS
+レバノン	Lebanon	422	LBN	LB	中東	ISO 3166-2:LB
+レユニオン	Réunion	638	REU	RE	インド洋地域	ISO 3166-2:RE
+ロシア連邦	Russian Federation	643	RUS	RU	ロシア	ISO 3166-2:RU


### PR DESCRIPTION
Test data include alt-text of image tag at copy and paste, so remove alt-text.